### PR TITLE
[fix] solve a11y event issue on ThemeToggle

### DIFF
--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -35,7 +35,7 @@
 	})
 </script>
 
-<div class="wrapper" on:click={toggleTheme}>
+<div class="wrapper" on:click={toggleTheme} on:keypress={() => {}}>
 	{#if ready && currentTheme}
 		<slot>
 			{#key currentTheme}


### PR DESCRIPTION
Adds an empty `on:keypress` event response to solve an accessibility warning specified here:
https://github.com/sveltejs/svelte/blob/7d20194d8ae9b600936e47826de53eb4f75e58e1/site/content/docs/06-accessibility-warnings.md#a11y-click-events-have-key-events